### PR TITLE
Sequence.forAll has been renamed to for_each

### DIFF
--- a/src/idiom30ex2.fz
+++ b/src/idiom30ex2.fz
@@ -4,6 +4,6 @@ ex30 is
     say "**$i**"
 
   (1..1000).mapSequence (i-> concur.thread.spawn (() -> f i))
-    .forAll x->unit
+    .for_each x->unit
 
   time.nano.sleep (time.durations.s 2)


### PR DESCRIPTION
Depends on tokiwa-software/fuzion#688.