### PR TITLE
Idiom #168: fix a mistake

### DIFF
--- a/src/idiom168ex.fz
+++ b/src/idiom168ex.fz
@@ -1,4 +1,4 @@
-ex168 isbyte
+ex168 is
 
   doit(s, p string) =>
     t := if s.endsWith p


### PR DESCRIPTION
Reverts a mistake that was introduced in
e8d5f1e3d3e322632683598eddfb38f1f232504b.