### PR TITLE
idiom 60: fix use of `envir.args` effect

### DIFF
--- a/src/idiom60ex2.fz
+++ b/src/idiom60ex2.fz
@@ -14,9 +14,9 @@ ex60 is
 
   # run showArgs in a different environment using a different instance of the
   # envir.args effect
-  envir.args ["cmd","arg0","arg1"] ()->
+  (envir.args ["cmd","arg0","arg1"]).go ()->
     showArgs
 
   # run showArgs in another environment
-  envir.args (array 20 i->"a$i") ()->
+  (envir.args (array 20 i->"a$i")).go ()->
     showArgs


### PR DESCRIPTION
The syntax change is due to switching the `envir.args` effect to `simpleEffect`.

Closes tokiwa-software/fuzion#1311.