### PR TITLE
idioms: various fixes:

### DIFF
--- a/src/idiom120ex.fz
+++ b/src/idiom120ex.fz
@@ -1,9 +1,13 @@
 ex120 is
   say "please type a number:"
 
-  # no error handling is performed here
-  # program crashes if user does not type a number
-  _ := io.stdin.with ()->
-    n := io.buffered.read_line ? str String => str.parse_int.val | io.end_of_file => panic "end of file"
+  # NYI: CLEANUP: there should be no need for a mutate effect
+  m : mutate.
+  m.instate_self ()->
 
-    say "got $n"
+    # no error handling is performed here
+    # program crashes if user does not type a number
+    _ := (io.stdin m).with  ()->
+      n := io.buffered.read_line m ? str String => str.parse_int.val | io.end_of_file => panic "end of file"
+
+      say "got $n"

--- a/src/idiom123ex.fz
+++ b/src/idiom123ex.fz
@@ -2,8 +2,9 @@ ex123 is
 
   # assert that n is lower than 10
   assert_n_lt_10(n i32)
-  pre n < 10
-  is
+    pre
+      n < 10
+  =>
     say "assertion passed for: $n"
 
   for i in 0..9 do

--- a/src/idiom259ex2.fz
+++ b/src/idiom259ex2.fz
@@ -1,7 +1,7 @@
 ex259 is
   strings := ["a-b_c,d", "-a--cc_,eee,ffff_", "---", ",_-", "abcd", ""]
 
-  seperators := container.set_of_ordered String [",", "-", "_"]
+  seperators := container.set_of_ordered [",", "-", "_"]
 
   for s in strings do
 


### PR DESCRIPTION
- add local mutate type parameter to io.stdin

- fix error due to ignored result type of `assert`

- fix type `codepoint` vs `String`